### PR TITLE
Make FMask compatible with newer NumPy versions

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1172,9 +1172,14 @@ def normalize_image(image, **kwargs):
     else:
         image_valid = image[np.where(obsmask)].astype("float")
 
-    [min_val, max_val] = np.percentile(
-        image_valid, percentile_range, interpolation="linear"
-    )
+    if np.__version__ >= '1.22.0':
+        [min_val, max_val] = np.percentile(
+            image_valid, percentile_range, method='linear'
+        )
+    else:
+        [min_val, max_val] = np.percentile(
+            image_valid, percentile_range, interpolation='linear'
+        )
     # normal_minmax_range = [min_val, max_val]
     # rescale
     image_scaled = ((image - min_val) / (max_val - min_val + C.EPS)) * (


### PR DESCRIPTION
Hi guys,

As the title says, it seems that FMask doesn't work with recent NumPy versions (>= 05/2022) currently. Indeed, `np.percentile` changed in NumPy version 1.22.0 (the "interpolation" argument is now called “method”), making the whole process crash (at least for L8 products, using the recommended settings).
This PR solves this issue.

Cheers,
Arthur