### PR TITLE
fix: use OMP_NUM_THREADS to control parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,15 @@ Each pixel is classified with one of the following values:
 > **Note:** Water and snow/ice pixels are labeled solely to enhance cloud detection. Their detection accuracy has not been evaluated.
 
 ### Computing Efficiency
-TBD
+
+Fmask's LightGBM inference (and local retraining) and PyTorch CPU inference both respect the `OMP_NUM_THREADS` environment variable. Set it to match the number of vCPUs available:
+
+```bash
+export OMP_NUM_THREADS=4
+fmask --imagepath /path/to/image --model UPL
+```
+
+If `OMP_NUM_THREADS` is not set, LightGBM defaults to using all physical cores. When running on GPU (CUDA or Apple MPS), PyTorch inference is unaffected by this variable.
 
 ### Global Validation Dataset
 The global validation samples are available at [this link](https://uconn-my.sharepoint.com/:x:/g/personal/shi_qiu_uconn_edu/IQCOGXrB23p-SLBu0exv5WJBAS71rzu1JA8IsvZxC_tM7Gg?e=fVkXH6).

--- a/main/job/slurm_job_run_fmask.sh
+++ b/main/job/slurm_job_run_fmask.sh
@@ -20,6 +20,8 @@ conda activate fmask
 echo $SLURMD_NODENAME # display the node name
 cd ../
 
+# Set LightGBM and other programs to use threadcount equal to CPUs for task
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 
 DCLOUD=3
 DSHADOW=5

--- a/src/lightgbmlib.py
+++ b/src/lightgbmlib.py
@@ -554,9 +554,9 @@ class LightGBM(object):
             sample_image_col = sample_image_col_all[idx:idx_end]
             if point_predictors: # image-based predictors + latitude + longitude
                 n_pixels = len(sample_image_row)
-                pro_pred = self.model.predict_proba((np.concatenate((self.image.data.get(image_predictors)[:, sample_image_row, sample_image_col], np.full((1, n_pixels), self.image.lat_center, dtype=np.float32), np.full((1, n_pixels), self.image.lon_center, dtype=np.float32)), axis=0)).T)
+                pro_pred = self.model.predict_proba((np.concatenate((self.image.data.get(image_predictors)[:, sample_image_row, sample_image_col], np.full((1, n_pixels), self.image.lat_center, dtype=np.float32), np.full((1, n_pixels), self.image.lon_center, dtype=np.float32)), axis=0)).T, n_jobs=0)
             else: # only image-based predictors
-                pro_pred = self.model.predict_proba((self.image.data.get(image_predictors)[:,sample_image_row, sample_image_col]).T)
+                pro_pred = self.model.predict_proba((self.image.data.get(image_predictors)[:,sample_image_row, sample_image_col]).T, n_jobs=0)
             
             label_pred = labs_model[np.argmax(pro_pred, axis=1)]
 

--- a/src/lightgbmlib.py
+++ b/src/lightgbmlib.py
@@ -425,7 +425,7 @@ class LightGBM(object):
                                    min_data_in_leaf = self.min_data_in_leaf,
                                    n_estimators=self.ntrees,
                                    random_state = C.RANDOM_SEED,
-                                   n_jobs  = 1, # only use 1 core to process, since we can use parallel processing for each individual image
+                                   n_jobs  = 0, # thread count follows OMP_NUM_THREADS; defaults to all physical cores if unset
                                    verbose = -1) # no verbose, do not show the warnings in the progress
     
         if (


### PR DESCRIPTION
## Description

For cloudy scenes the LightGBM classification, retraining, and re-classification phases can take a significant proportion of the overall runtime. The code is currently written assuming that users will run in a CPU=1 constrained environment. In cloud processing environments compute resources are often limited to 8GB of memory per vCPU, and since Fmask v5 can require a significantly more than 8GB of memory we often have excess CPU resources available.

The change in this PR updates the LightGBM code to change the hard coded `n_jobs=1` to `n_jobs=0`, allowing the `OMP_NUM_THREADS` environment variable (a common standard) to define the number of threads used for fitting and predictions [1]. Other libraries including NumPy can use this environment variable for operations like linear algebra (via BLAS or Intel MKL) [2].

With this change I noticed an average ~30 second or ~5% runtime performance improvement with `OMP_NUM_THREADS=2` compared to the hard coded `n_jobs=1` when run over ~400 granules of Sentinel-2 and Landsat. This is a relatively small percent, but can add up to significant cost savings when run at scale. I also noticed locally that the speedup continued to scale with 3 to 4 CPUs.

[1] https://lightgbm.readthedocs.io/en/latest/Parameters-Tuning.html#add-more-computational-resources
[2] https://numpy.org/devdocs/reference/global_state.html#number-of-threads-used-for-linear-algebra

## What I changed

- I set `n_jobs=0` in the model initialization and `fit()` calls and updated the comment
- I added a section to the README under "Computing Efficiency" about this setting
- I updated the `slurm_job_run_fmask.sh` script to set `OMP_NUM_THREADS` based on the compute resources for the Slurm job (ref https://slurm.schedmd.com/sbatch.html)